### PR TITLE
Httpcheck method incorrect in example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,11 @@
+=============================
+pfSensible.HAProxy Release Notes
+=============================
+
+.. contents:: Topics
+
+
+v0.1.0
+======
+
+This simply moved the pfsense_haproxy_backend and pfsense_haproxy_backend_server modules from version 0.6.0 of pfsensible.core to pfsensible.haproxy.

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,32 @@
+changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_version_depth: 0
+changes_file: changelog.yaml
+changes_format: combined
+ignore_other_fragment_extensions: true
+keep_fragments: false
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sanitize_changelog: true
+sections:
+- - major_changes
+  - Major Changes
+- - minor_changes
+  - Minor Changes
+- - breaking_changes
+  - Breaking Changes / Porting Guide
+- - deprecated_features
+  - Deprecated Features
+- - removed_features
+  - Removed Features (previously deprecated)
+- - security_fixes
+  - Security Fixes
+- - bugfixes
+  - Bugfixes
+- - known_issues
+  - Known Issues
+title: pfSensible.HAProxy
+trivial_section_name: trivial
+use_fqcn: true

--- a/changelogs/fragments/httpcheck_method.yml
+++ b/changelogs/fragments/httpcheck_method.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Update example for pfsense_haproxy_backend httpcheck_method to use OPTION instead of invalid HTTP.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.12"

--- a/plugins/modules/pfsense_haproxy_backend.py
+++ b/plugins/modules/pfsense_haproxy_backend.py
@@ -69,7 +69,9 @@ options:
     required: false
     type: bool
   httpcheck_method:
-    description: HTTP check method.
+    description: HTTP check method. OPTIONS is the method usually best to perform server checks, HEAD and GET can also be used. If the server gets marked as
+      down in the stats page then changing this to GET usually has the biggest chance of working, but might cause more processing overhead on the websever and
+      is less easy to filter out of its logs.
     required: false
     type: str
     choices: ['OPTIONS', 'HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'TRACE']
@@ -98,14 +100,14 @@ options:
 
 EXAMPLES = """
 - name: Add backend
-  pfsense_haproxy_backend:
+  pfsensible.haproxy.pfsense_haproxy_backend:
     name: exchange
     balance: leastconn
-    httpcheck_method: HTTP
+    httpcheck_method: OPTIONS
     state: present
 
 - name: Remove backend
-  pfsense_haproxy_backend:
+  pfsensible.haproxy.pfsense_haproxy_backend:
     name: exchange
     state: absent
 """
@@ -115,7 +117,7 @@ commands:
     description: the set of commands that would be pushed to the remote device (if pfSense had a CLI)
     returned: always
     type: list
-    sample: ["create haproxy_backend 'exchange', balance='leastconn', httpcheck_method='HTTP'", "delete haproxy_backend 'exchange'"]
+    sample: ["create haproxy_backend 'exchange', balance='leastconn', httpcheck_method='OPTIONS'", "delete haproxy_backend 'exchange'"]
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/plays/haproxy.yml
+++ b/tests/plays/haproxy.yml
@@ -1,0 +1,15 @@
+---
+- hosts: pfsense
+  gather_facts: false
+  tasks:
+    - name: Add backend
+      pfsensible.haproxy.pfsense_haproxy_backend:
+        name: exchange
+        balance: leastconn
+        httpcheck_method: OPTIONS
+        state: present
+
+    - name: Remove backend
+      pfsensible.haproxy.pfsense_haproxy_backend:
+        name: exchange
+        state: absent


### PR DESCRIPTION
Update example for pfsense_haproxy_backend httpcheck_method to use OPTION instead of invalid HTTP.